### PR TITLE
fix compilation error: IdentifierDefSubtree has 2 constructor parameters

### DIFF
--- a/src/java/org/antlr/jetbrains/sample/SampleParserDefinition.java
+++ b/src/java/org/antlr/jetbrains/sample/SampleParserDefinition.java
@@ -162,11 +162,11 @@ public class SampleParserDefinition implements ParserDefinition {
 		RuleIElementType ruleElType = (RuleIElementType) elType;
 		switch ( ruleElType.getRuleIndex() ) {
 			case SampleLanguageParser.RULE_function :
-				return new FunctionSubtree(node);
+				return new FunctionSubtree(node, elType);
 			case SampleLanguageParser.RULE_vardef :
-				return new VardefSubtree(node);
+				return new VardefSubtree(node, elType);
 			case SampleLanguageParser.RULE_formal_arg :
-				return new ArgdefSubtree(node);
+				return new ArgdefSubtree(node, elType);
 			case SampleLanguageParser.RULE_block :
 				return new BlockSubtree(node);
 			case SampleLanguageParser.RULE_call_expr :

--- a/src/java/org/antlr/jetbrains/sample/psi/ArgdefSubtree.java
+++ b/src/java/org/antlr/jetbrains/sample/psi/ArgdefSubtree.java
@@ -1,10 +1,11 @@
 package org.antlr.jetbrains.sample.psi;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
 
 public class ArgdefSubtree extends VardefSubtree {
-	public ArgdefSubtree(@NotNull ASTNode node) {
-		super(node);
+	public ArgdefSubtree(@NotNull ASTNode node, @NotNull IElementType idElementType) {
+		super(node, idElementType);
 	}
 }

--- a/src/java/org/antlr/jetbrains/sample/psi/FunctionSubtree.java
+++ b/src/java/org/antlr/jetbrains/sample/psi/FunctionSubtree.java
@@ -3,6 +3,7 @@ package org.antlr.jetbrains.sample.psi;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.tree.IElementType;
 import org.antlr.jetbrains.adaptor.SymtabUtils;
 import org.antlr.jetbrains.adaptor.psi.IdentifierDefSubtree;
 import org.antlr.jetbrains.adaptor.psi.ScopeNode;
@@ -14,8 +15,8 @@ import org.jetbrains.annotations.Nullable;
  *  Its scope is the set of arguments.
  */
 public class FunctionSubtree extends IdentifierDefSubtree implements ScopeNode {
-	public FunctionSubtree(@NotNull ASTNode node) {
-		super(node);
+	public FunctionSubtree(@NotNull ASTNode node, @NotNull IElementType idElementType) {
+		super(node, idElementType);
 	}
 
 	@Nullable

--- a/src/java/org/antlr/jetbrains/sample/psi/VardefSubtree.java
+++ b/src/java/org/antlr/jetbrains/sample/psi/VardefSubtree.java
@@ -1,11 +1,12 @@
 package org.antlr.jetbrains.sample.psi;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.IElementType;
 import org.antlr.jetbrains.adaptor.psi.IdentifierDefSubtree;
 import org.jetbrains.annotations.NotNull;
 
 public class VardefSubtree extends IdentifierDefSubtree {
-	public VardefSubtree(@NotNull ASTNode node) {
-		super(node);
+	public VardefSubtree(@NotNull ASTNode node, @NotNull IElementType idElementType) {
+		super(node, idElementType);
 	}
 }


### PR DESCRIPTION
Hi,

with https://github.com/antlr/jetbrains commit 2f5bfb8 (current master at the time of writing) the plugin would not compile.
IdentifierDefSubtree has 2 constructor parameters but only one was passed.

After the change, I ran the plugin and it worked.

Best regards,
Mathias